### PR TITLE
Allow xmlbuilder2 v4 (widen range to ^3 || ^4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
   },
   "dependencies": {
     "react-is": "^18.3.1",
-    "xmlbuilder2": "^3.1.1"
+    "xmlbuilder2": "^3.1.1 || ^4.0.0"
   }
 }


### PR DESCRIPTION
## What

Widens the `xmlbuilder2` dependency range from `^3.1.1` to `^3.1.1 || ^4.0.0` so jsx-xml can be used in projects that resolve xmlbuilder2 to v4.

## Why

xmlbuilder2 v3 pulls in `js-yaml@3`, which has known DoS advisories ([GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68), [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m)). xmlbuilder2 v4 depends on `js-yaml@^4.1.1`, which is unaffected. While jsx-xml is pinned to `xmlbuilder2@^3.1.1`, downstream consumers can't cleanly resolve the fixed version without an `overrides` workaround.

jsx-xml only uses xmlbuilder2's stable core builder API (`create`, `.ele`, `.att`, `.txt`, `.com`, `.dat`, `.ins`, `.end`) and the `XMLBuilder` / `XMLBuilderCreateOptions` types from `xmlbuilder2/lib/interfaces` — all unchanged in v4.

## Verification

Against `xmlbuilder2@4.0.3`:

- `tsc --noEmit` — passes (type imports from `xmlbuilder2/lib/interfaces` still resolve)
- `vitest --run` — all 66 tests pass
- No source changes; dependency-range change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)